### PR TITLE
Fixed Team Drive name error that caused it to display thousands of empty lines on android.

### DIFF
--- a/sgd/meta.py
+++ b/sgd/meta.py
@@ -82,7 +82,7 @@ class IMDb:
         """Obtain metadata from imdb suggestions api"""
         meta = ut.req_api(self.imdb_sg_url, key="d")
         if meta:
-            self.set_meta(meta[0], year="y", name="l")
+            self.set_meta(meta[0], year="y")
             return True
         return False
 

--- a/sgd/meta.py
+++ b/sgd/meta.py
@@ -82,7 +82,7 @@ class IMDb:
         """Obtain metadata from imdb suggestions api"""
         meta = ut.req_api(self.imdb_sg_url, key="d")
         if meta:
-            self.set_meta(meta[0], year="y")
+            self.set_meta(meta[0], year="y", title="l")
             return True
         return False
 

--- a/sgd/streams.py
+++ b/sgd/streams.py
@@ -52,6 +52,9 @@ class Streams:
         drive_id = self.item.get("driveId")
         drive_name = self.gdrive.drive_names.contents.get(drive_id, "MyDrive")
 
+        if len(drive_name) > 100 :
+            drive_name="TeamDrive Name Error"
+
         str_format = "🎥;%codec 🌈;%bitDepth;bit 🔊;%audio 👤;%encoder"
         suffix = self.parsed.get_str(str_format)
         return f"{file_name}\n💾 {file_size} ☁️ {drive_name}\n{suffix}"


### PR DESCRIPTION
![image](https://github.com/ShuvamJaswal/Gdrive-Stremio-Update/assets/64459957/e70cbd34-d296-4415-a12b-7ed45f6e85af)
Fixing this error